### PR TITLE
test a read -a workaround

### DIFF
--- a/gs/gs.bash
+++ b/gs/gs.bash
@@ -10,7 +10,15 @@ gs() {
 	# Parse current repo-relative path into array
 	# Example: if current path is project/src/utils, then dirs=["project","src","utils"]
 	local -a dirs
-	IFS=/ read -r -a dirs <<< "$(git rev-parse --show-prefix)"
+
+	# OSX BSD fix
+	local prefix
+	prefix="$(git rev-parse --show-prefix)"
+	prefix=${prefix%/}
+	IFS='/'
+	dirs=($prefix)
+	unset IFS
+	#IFS=/ read -r -a dirs <<< "$(git rev-parse --show-prefix)"
 
 	local gs_path index
 	local command="${1:-}"


### PR DESCRIPTION
This fixes the issue with `read -a` not being supported on OSX BSD version of `read`