### PR TITLE
fix(zsh): correct array initialization in path parsing

### DIFF
--- a/gs/gs.zsh
+++ b/gs/gs.zsh
@@ -16,7 +16,7 @@ gs() {
 	prefix="$(git rev-parse --show-prefix)"
 	prefix=${prefix%/}
 	IFS='/'
-	dirs=("${(s:/:)prefix}")
+	dirs=(${(s:/:)prefix})
 	unset IFS
 
 	local gs_path index


### PR DESCRIPTION
## Overview

Fixes array initialization for the `dirs` variable in `gs.zsh` to properly handle path splitting in Zsh, ensuring directory traversal works correctly when resolving `_gs` commands.

## Details

> [!NOTE]
> - Changed `dirs=("${(s:/:)prefix}")` to `dirs=(${(s:/:)prefix})` in `gs.zsh` line 19 to fix array initialization syntax

---

## Additional Summary: Technical Detail

Zsh parameter expansion flag `(s:/:)` performs string splitting on delimiter `/`. When wrapped in double quotes (`"${(s:/:)prefix}"`), Zsh treats the entire result as a single array element rather than splitting it into multiple elements. Removing the quotes (`${(s:/:)prefix}`) allows the split result to correctly populate the array with individual path segments.

Example: if `prefix="example/js/project-b"`, the quoted version creates `dirs=("example/js/project-b")` (1 element), while the unquoted version creates `dirs=(example js project-b)` (3 elements). The function requires the multi-element form for directory traversal logic.